### PR TITLE
Update key generation description

### DIFF
--- a/cmd/teams-cli/keys.go
+++ b/cmd/teams-cli/keys.go
@@ -25,7 +25,7 @@ func buildKeysCmd() *cobra.Command {
 func buildGenerateKeyCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "generate",
-		Short: "Generate a new public and private key pais",
+		Short: "Generate a new public and private key pair.",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			username := args[0]


### PR DESCRIPTION
## Summary
- tweak the short description for `generate` keys command

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843299dd7c8832fb8ab3a5199f7f413